### PR TITLE
Modularize transfer list view

### DIFF
--- a/src/components/transfers/ListView.tsx
+++ b/src/components/transfers/ListView.tsx
@@ -1,0 +1,73 @@
+import { memo, useMemo } from "react"
+import { Virtuoso } from "react-virtuoso"
+import { ArrowDownUp } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import type { Transfer } from "@/stores/transfers.store"
+
+export interface TransferListViewProps {
+    transfers: Transfer[]
+    height: number
+    getItemKey: (index: number, transfer: Transfer) => string
+    itemContent: (index: number, transfer: Transfer) => React.ReactElement
+    onDragOver?: (e: React.DragEvent<HTMLDivElement>) => void
+    overscan?: number | { main: number; reverse: number }
+    style?: React.CSSProperties
+}
+
+export const TransferListView = memo(
+    ({
+        transfers,
+        height,
+        getItemKey,
+        itemContent,
+        onDragOver,
+        overscan = 0,
+        style
+    }: TransferListViewProps) => {
+        const { t } = useTranslation()
+
+        const components = useMemo(() => {
+            return {
+                EmptyPlaceholder: () => (
+                    <div
+                        className="w-full flex flex-col items-center justify-center text-muted-foreground gap-2"
+                        style={{ height }}
+                    >
+                        <ArrowDownUp size={60} />
+                        <p>{t("transfers.noActiveTransfers")}</p>
+                    </div>
+                )
+            }
+        }, [height, t])
+
+        const computedStyle = useMemo((): React.CSSProperties => {
+            return {
+                overflowX: "hidden",
+                overflowY: "auto",
+                height: height + "px",
+                width: "100%",
+                ...style
+            }
+        }, [height, style])
+
+        return (
+            <Virtuoso
+                data={transfers}
+                totalCount={transfers.length}
+                height={height}
+                width="100%"
+                computeItemKey={getItemKey}
+                itemContent={itemContent}
+                onDragOver={onDragOver}
+                defaultItemHeight={78}
+                components={components}
+                overscan={overscan}
+                style={computedStyle}
+            />
+        )
+    }
+)
+
+TransferListView.displayName = "TransferListView"
+
+export default TransferListView

--- a/src/components/transfers/index.ts
+++ b/src/components/transfers/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./index.tsx"
+export { default as TransferListView } from "./ListView"

--- a/src/components/transfers/index.tsx
+++ b/src/components/transfers/index.tsx
@@ -5,10 +5,10 @@ import useWindowSize from "@/hooks/useWindowSize"
 import eventEmitter from "@/lib/eventEmitter"
 import { type WorkerToMainMessage } from "@/lib/worker/types"
 import { useTransfersStore, type TransferState, type Transfer as TransferType } from "@/stores/transfers.store"
-import { Virtuoso } from "react-virtuoso"
+import TransferListView from "./ListView"
 import { calcSpeed, calcTimeLeft, getTimeRemaining, bpsToReadable } from "./utils"
 import throttle from "lodash/throttle"
-import { ArrowDownUp, Play, Pause, XCircle } from "lucide-react"
+import { Play, Pause, XCircle } from "lucide-react"
 import { IS_DESKTOP } from "@/constants"
 import Transfer from "./transfer"
 import { type MainToWindowMessage } from "@filen/desktop/dist/ipc"
@@ -370,32 +370,6 @@ export const Transfers = memo(() => {
 		}
 	}, [paused, errorToast, transfers, setTransfers])
 
-	const style = useMemo((): React.CSSProperties => {
-		return {
-			overflowX: "hidden",
-			overflowY: "auto",
-			height: virtuosoHeight + "px",
-			width: "100%"
-		}
-	}, [virtuosoHeight])
-
-	const components = useMemo(() => {
-		return {
-			EmptyPlaceholder: () => {
-				return (
-					<div
-						className="w-full flex flex-col items-center justify-center text-muted-foreground gap-2"
-						style={{
-							height: virtuosoHeight
-						}}
-					>
-						<ArrowDownUp size={60} />
-						<p>{t("transfers.noActiveTransfers")}</p>
-					</div>
-				)
-			}
-		}
-	}, [virtuosoHeight, t])
 
 	const onOpenChange = useCallback(
 		(o: boolean) => {
@@ -467,19 +441,14 @@ export const Transfers = memo(() => {
 				<SheetHeader className="mb-4">
 					<SheetTitle>{transfersSorted.length > 0 && t("transfers.title")}</SheetTitle>
 				</SheetHeader>
-				<Virtuoso
-					data={transfersSorted}
-					totalCount={transfersSorted.length}
-					height={virtuosoHeight}
-					width="100%"
-					computeItemKey={getItemKey}
-					itemContent={itemContent}
-					onDragOver={onDragOver}
-					defaultItemHeight={78}
-					components={components}
-					overscan={0}
-					style={style}
-				/>
+                                <TransferListView
+                                        transfers={transfersSorted}
+                                        height={virtuosoHeight}
+                                        getItemKey={getItemKey}
+                                        itemContent={itemContent}
+                                        onDragOver={onDragOver}
+                                        overscan={0}
+                                />
 				<div className="flex flex-row items-center gap-3 h-12 text-muted-foreground justify-end text-sm">
 					{remaining > 0 && remainingReadable.length > 0 && remaining < Infinity && (
 						<>


### PR DESCRIPTION
## Summary
- extract `TransferListView` component
- use `TransferListView` in transfer sheet
- label `TransferListView` to aid debugging

## Testing
- `npm run lint`
- `npm run tsc`


------
https://chatgpt.com/codex/tasks/task_e_68622a95c8c4832cb2399c5ef5f9aa2b