### PR TITLE
Fix alias management race conditions

### DIFF
--- a/src/components/drive/list/item/contextMenu/index.tsx
+++ b/src/components/drive/list/item/contextMenu/index.tsx
@@ -104,7 +104,7 @@ export const ContextMenu = memo(
 		const publicLinkURLState = usePublicLinkURLState()
 		const isServiceWorkerOnline = useIsServiceWorkerOnline()
 		const isDesktopHTTPServerOnline = useIsDesktopHTTPServerOnline()
-		const { aliases: aliasMap, addAlias, addItemToAlias, removeItemFromAlias, getItemAliases, removeAlias } = useDriveAliases()
+               const { aliases: aliasMap, addAlias, addItemToAlias, removeItemFromAlias, getItemAliases } = useDriveAliases()
 		const itemAliases = useMemo(() => getItemAliases(item.uuid), [getItemAliases, item.uuid])
 
 		const isInsidePublicLink = useMemo(() => {
@@ -1127,9 +1127,6 @@ export const ContextMenu = memo(
                                                                                 key={alias}
                                                                                 onClick={() => {
                                                                                         removeItemFromAlias(alias, item.uuid)
-                                                                                        if ((aliasMap[alias]?.length ?? 1) <= 1) {
-                                                                                                removeAlias(alias)
-                                                                                        }
                                                                                 }}
                                                                                 className="cursor-pointer"
                                                                         >
@@ -1239,7 +1236,6 @@ export const ContextMenu = memo(
                         itemAliases,
                         aliasMap,
                        openAliasLocation,
-                        removeAlias,
                         manageShareOut,
 			removeShared,
 			isDesktopHTTPServerOnline,

--- a/src/hooks/useDriveAliases.ts
+++ b/src/hooks/useDriveAliases.ts
@@ -94,13 +94,13 @@ export default function useDriveAliases() {
                                return
                        }
 
-                       const remaining = items.length - 1
-
                        try {
                                await worker.removeDriveItemFromAlias({ alias, uuid })
                                removeItemFromAlias(alias, uuid)
 
-                               if (remaining <= 0) {
+                               const updatedItems = useAliasesStore.getState().aliases[alias]
+
+                               if (!updatedItems || updatedItems.length === 0) {
                                        removeAlias(alias)
                                }
                        } catch (e) {

--- a/src/hooks/useDriveAliases.ts
+++ b/src/hooks/useDriveAliases.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect } from "react"
 import { useAliasesStore } from "@/stores/aliases.store"
 import worker from "@/lib/worker"
+import useErrorToast from "@/hooks/useErrorToast"
 
 export default function useDriveAliases() {
        const { aliases, setAliases, addAlias, removeAlias, addItemToAlias, removeItemFromAlias, getItemAliases } = useAliasesStore(state => ({
@@ -12,13 +13,17 @@ export default function useDriveAliases() {
                removeItemFromAlias: state.removeItemFromAlias,
                getItemAliases: state.getItemAliases
        }))
+       const errorToast = useErrorToast()
 
        useEffect(() => {
                worker
                        .listDriveAliases()
                        .then(result => setAliases(result))
-                       .catch(console.error)
-       }, [setAliases])
+                       .catch(e => {
+                               console.error(e)
+                               errorToast((e as unknown as Error).message ?? (e as unknown as Error).toString())
+                       })
+       }, [setAliases, errorToast])
 
        const validatedAddAlias = useCallback(
                async (name: string) => {
@@ -28,10 +33,15 @@ export default function useDriveAliases() {
                                return
                        }
 
-                       await worker.createDriveAlias({ name: trimmed })
-                       addAlias(trimmed)
+                       try {
+                               await worker.createDriveAlias({ name: trimmed })
+                               addAlias(trimmed)
+                       } catch (e) {
+                               console.error(e)
+                               errorToast((e as unknown as Error).message ?? (e as unknown as Error).toString())
+                       }
                },
-               [aliases, addAlias]
+               [aliases, addAlias, errorToast]
        )
 
        const validatedRemoveAlias = useCallback(
@@ -40,10 +50,15 @@ export default function useDriveAliases() {
                                return
                        }
 
-                       await worker.deleteDriveAlias({ name })
-                       removeAlias(name)
+                       try {
+                               await worker.deleteDriveAlias({ name })
+                               removeAlias(name)
+                       } catch (e) {
+                               console.error(e)
+                               errorToast((e as unknown as Error).message ?? (e as unknown as Error).toString())
+                       }
                },
-               [aliases, removeAlias]
+               [aliases, removeAlias, errorToast]
        )
 
        const validatedAddItemToAlias = useCallback(
@@ -60,10 +75,15 @@ export default function useDriveAliases() {
 				return
 			}
 
-                       await worker.addDriveItemToAlias({ alias: trimmedAlias, uuid })
-                       addItemToAlias(trimmedAlias, uuid)
+                       try {
+                               await worker.addDriveItemToAlias({ alias: trimmedAlias, uuid })
+                               addItemToAlias(trimmedAlias, uuid)
+                       } catch (e) {
+                               console.error(e)
+                               errorToast((e as unknown as Error).message ?? (e as unknown as Error).toString())
+                       }
                },
-               [aliases, addItemToAlias]
+               [aliases, addItemToAlias, errorToast]
        )
 
        const validatedRemoveItemFromAlias = useCallback(
@@ -74,10 +94,21 @@ export default function useDriveAliases() {
                                return
                        }
 
-                       await worker.removeDriveItemFromAlias({ alias, uuid })
-                       removeItemFromAlias(alias, uuid)
+                       const remaining = items.length - 1
+
+                       try {
+                               await worker.removeDriveItemFromAlias({ alias, uuid })
+                               removeItemFromAlias(alias, uuid)
+
+                               if (remaining <= 0) {
+                                       removeAlias(alias)
+                               }
+                       } catch (e) {
+                               console.error(e)
+                               errorToast((e as unknown as Error).message ?? (e as unknown as Error).toString())
+                       }
                },
-               [aliases, removeItemFromAlias]
+               [aliases, removeItemFromAlias, removeAlias, errorToast]
        )
 
 	return {


### PR DESCRIPTION
### **User description**
## Summary
- serialize drive alias updates with `aliasMutex`
- add toast-based error handling to `useDriveAliases`
- guard alias deletion logic in item context menu
- fix alias item removal flow and update hook dependencies

## Testing
- `npm run lint`
- `npm run tsc`


------
https://chatgpt.com/codex/tasks/task_e_6864624927e0832cbf395c371da7cf65


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix race conditions in drive alias operations with mutex serialization

- Add comprehensive error handling with toast notifications

- Improve alias item removal flow with automatic cleanup

- Update hook dependencies for proper error handling


___

### **Changes diagram**

```mermaid
flowchart LR
  A["useDriveAliases Hook"] --> B["Error Toast Integration"]
  A --> C["Worker Operations"]
  C --> D["Alias Mutex Serialization"]
  D --> E["Race Condition Prevention"]
  B --> F["User Error Feedback"]
  A --> G["Automatic Alias Cleanup"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useDriveAliases.ts</strong><dd><code>Enhanced error handling and alias cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hooks/useDriveAliases.ts

<li>Add <code>useErrorToast</code> hook for error handling<br> <li> Wrap all async operations in try-catch blocks<br> <li> Update hook dependencies to include <code>errorToast</code><br> <li> Add automatic alias removal when last item is removed


</details>


  </td>
  <td><a href="https://github.com/immateria/filen-web/pull/28/files#diff-6bde7c9b2c2abe29d88afc41ad9bbed7e56523e5e3477715c5a995ef683c900c">+45/-14</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>worker.ts</strong><dd><code>Serialize alias operations with mutex</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/worker/worker.ts

<li>Add <code>aliasMutex</code> semaphore for serializing alias operations<br> <li> Wrap all alias functions with mutex acquire/release<br> <li> Prevent race conditions in concurrent alias modifications


</details>


  </td>
  <td><a href="https://github.com/immateria/filen-web/pull/28/files#diff-237c7e8418cba724138fe42a8157aef78f21563177c16f973fdcc25dd0b2f7c1">+49/-24</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Simplify alias removal in context menu</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/drive/list/item/contextMenu/index.tsx

<li>Remove manual alias deletion logic from context menu<br> <li> Remove <code>removeAlias</code> from hook destructuring<br> <li> Simplify alias removal to only call <code>removeItemFromAlias</code>


</details>


  </td>
  <td><a href="https://github.com/immateria/filen-web/pull/28/files#diff-70388144ac510519327fcd86f21d8c2d078e9e59d00a1b11ce2c7865954aa766">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>